### PR TITLE
Added API wrappers; general cleanup.

### DIFF
--- a/API/ExternalAPI.lua
+++ b/API/ExternalAPI.lua
@@ -1,0 +1,118 @@
+-- ExternalAPI.lua
+
+--[[
+  This file is to be loaded by any plugin that wishes to use the BankAPI for its money management:
+-- In HOOK_PLUGINS_LOADED handler:
+dofile(cPluginManager:CallPlugin("BankAPI", "GetExternalAPIPath"))
+
+-- In eg. a command handler:
+BankGetPlayerBalance(uuid)...
+`--]]
+
+
+
+
+
+--- Returns the player's current account balance
+--[[
+WARNING: As soon as this function returns, another plugin may change that balance,
+so DO NOT base any critical calculations on this value, and especially DO NOT USE code like the following:
+SetPlayerBalance(somePlayer, GetPlayerBalance(somePlayer) + 100)
+Use ChangePlayerBalance() or TransferPlayerBalance() instead.
+--]]
+function BankGetPlayerBalance(aPlayerUuid)
+	assert(type(aPlayerUuid) == "string")
+
+	-- Call into the BankAPI plugin:
+	local bal = cPluginManager:CallPlugin("BankAPI", "GetBalance", aPlayerUuid)
+
+	-- Report failure if the plugin call failed:
+	if not(bal) then
+		-- Either the plugin call failed (bal == nil) or the plugin ran into a problem (bal == false)
+		-- Report an error either way
+		error("Failed to call the BankAPI plugin")
+	end
+
+	-- All ok, return the balance:
+	return bal
+end
+
+
+
+
+
+--- Sets the player's current account balance
+--[[
+Returns the player's new balance
+WARNING: Another plugin may change the balance at any time, DO NOT USE code like the following:
+SetPlayerBalance(somePlayer, GetPlayerBalance(somePlayer) + 100)
+Use ChangePlayerBalance() or TransferPlayerBalance() instead.
+--]]
+function BankSetPlayerBalance(aPlayerUuid, aNewBalance)
+	assert(type(aPlayerUuid) == "string")
+	assert(type(aNewBalance) == "number")
+
+	-- Call into the BankAPI plugin:
+	local bal = cPluginManager:CallPlugin("BankAPI", "SetBalance", aPlayerUuid, aNewBalance)
+
+	-- Report failure if the plugin call failed:
+	if not(bal) then
+		-- Either the plugin call failed (bal == nil) or the plugin ran into a problem (bal == false)
+		-- Report an error either way
+		error("Failed to call the BankAPI plugin")
+	end
+
+	-- All ok, return the new balance:
+	return bal
+end
+
+
+
+
+
+--- Changes the player's current account balance by the specified delta
+-- Returns the player's new balance
+function BankChangePlayerBalance(aPlayerUuid, aDelta)
+	assert(type(aPlayerUuid) == "string")
+	assert(type(aDelta) == "number")
+
+	-- Call into the BankAPI plugin:
+	local bal = cPluginManager:CallPlugin("BankAPI", "ChangeBalance", aPlayerUuid, aDelta)
+
+	-- Report failure if the plugin call failed:
+	if not(bal) then
+		-- Either the plugin call failed (bal == nil) or the plugin ran into a problem (bal == false)
+		-- Report an error either way
+		error("Failed to call the BankAPI plugin")
+	end
+
+	-- All ok, return the new balance:
+	return bal
+end
+
+
+
+
+
+--- Transfers aAmount from aFromPlayer to aToPlayer, if aFromPlayer has enough funds
+-- Returns true if transfer succeeds, false if not
+function BankTransferPlayerBalance(aFromPlayer, aToPlayer, aAmount)
+	assert(aFromPlayer)
+	assert(aToPlayer)
+	assert(type(aAmount) == "number")
+
+	-- Call into the BankAPI plugin:
+	local bal = cPluginManager:CallPlugin("BankAPI", "TransferBalance", aFromPlayer, aToPlayer, aAmount)
+
+	-- Report failure if the plugin call failed:
+	if (bal == nil) then
+		error("Failed to call the BankAPI plugin")
+	end
+
+	-- Plugin call succeeded, return the result:
+	return bal
+end
+
+
+
+

--- a/API/manage.lua
+++ b/API/manage.lua
@@ -1,28 +1,55 @@
-
 -- Manage.lua
 
--- Implements functions that can be called by external plugins
+--[[
+Implements functions that can be called by external plugins
+Note that usually external plugins will want to use the ExternalAPI instead (see that file for details)
+--]]
 
 
 
---- Sets the player's selection to the specified cuboid.
--- Returns true on success, false on failure.
-function GetBalance(Player)
-    return GetPlayerBalance(Player)
+
+
+--- Returns the player's current balance
+-- Returns the balance (number) on success, false on failure
+function GetBalance(aPlayerUuid)
+    return GetPlayerBalance(aPlayerUuid)
 end
 
-function SetBalance(Player, Bal)
-    return SetPlayerBalance(Player, Bal)
+
+
+
+
+--- Sets the player's current balance
+-- Returns the player's current balance on success, false on failure
+function SetBalance(aPlayerUuid, aNewBalance)
+    return SetPlayerBalance(aPlayerUuid, aNewBalance)
 end
 
-function AddBalance(Player, Bal)
-    return AddPlayerBalance(Player, Bal)
+
+
+
+
+--- Modifies the player's current balance by the specified amount
+-- Returns the player's new balance on success, false on failure
+function ChangeBalance(aPlayerUuid, aDelta)
+    return ChangePlayerBalance(aPlayerUuid, aDelta)
 end
 
-function RemoveBalance(Player, Bal)
-    return RemovePlayerBalance(Player, Bal)
+
+
+
+
+--- Transfers aAmount from aFromPlayer to aToPlayer, if aFromPlayer has enough funds
+-- Returns true if transfer succeeds, false if not
+function TransferBalance(aFromPlayerUuid, aToPlayerUuid, aAmount)
+    return TransferPlayerBalance(aFromPlayerUuid, aToPlayerUuid, aAmount)
 end
 
-function TransferBalance(aPlayer, bPlayer, Bal)
-    return TransferPlayerBalance(aPlayer, bPlayer, Bal)
+
+
+
+
+--- Returns the location of the ExternalAPI.lua file so that other plugins can load it directly
+function GetExternalAPIPath()
+	return cPluginManager:GetCurrentPlugin():GetLocalFolder() .. "/API/ExternalAPI.lua"
 end

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # BankAPI
-Economy Api for Cuberite
+Economy API for Cuberite
+
+This plugin provides a storage for players' accounts that other plugins can use (and share between them).
+
+
+
+
+
+# Interfacing
+
+To make your plugin use BankAPI, simply add this to your HOOK_PLUGINS_LOADED handler:
+```lua
+dofile(cPluginManager:CallPlugin("BankAPI", "GetExternalAPIPath"))
+```
+(This can be called multiple times with no ill effects)
+
+Then you can use all the functions in the API/ExternalAPI.lua file. See the individual functions there
+for their documentation.
+
+
+
+
+
+# Sample client plugin
+
+The following is a simple client plugin that uses the BankAPI:
+```lua
+local function TestBankAPI()
+	-- Load the BankAPI external API:
+	dofile(cPluginManager:CallPlugin("BankAPI", "GetExternalAPIPath"))
+
+	-- Use the BankAPI:
+	LOG("Adding 1000 to xoft's balance...")
+	local uuid = cMojangAPI:GetUUIDFromPlayerName("xoft", false)
+	local bal = BankChangePlayerBalance(uuid, 1000)
+	if (bal) then
+		LOG("Added successfully, new balance is " .. bal)
+	else
+		LOG("Failed to change balance")
+	end
+end
+
+function Initialize()
+	cPluginManager:BindConsoleCommand("add", TestBankAPI, "Tests the BankAPI by trying to add 1000 to xoft's balance")
+	return true
+end
+```


### PR DESCRIPTION
Converted the functions to use Uuids instead of cPlayer, so that they can be used from console commands.
Only open the DB once on plugin start, re-use the instance everywhere.
Redefined the API functions.
Added API wrappers and instructions on how to use them.